### PR TITLE
Delete .gitignore

### DIFF
--- a/ArchImpl/RV64GCV/.gitignore
+++ b/ArchImpl/RV64GCV/.gitignore
@@ -1,6 +1,0 @@
-./RV64GCV.h
-./RV64GCV.html
-./RV64GCVArchLib.h
-./RV64GCVArchLib.cpp
-./RV64GCVArch.cpp
-./RV64GCVArch.h


### PR DESCRIPTION
What is the motivation behind this .gitignore? Some of the ignored files are present in the repo? Is that intended? 

Was the motivation to not keep the autogenerated files from M2-ISA-R in the repo? If so, why are only some of them ignored?

Thanks in advance :)

Ps.: Since I can't open any issues on your ETISS fork I am "abusing" this PR.